### PR TITLE
Add LORA Chipmode and Init functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cstdint": "cpp"
+    }
+}

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -166,10 +166,20 @@ LORA_STATUS lora_init( LORA_CONFIG *lora_config_ptr ) {
     // Get initial value of config register 1
     uint8_t modem_config1_register;
     LORA_STATUS read_status3 = lora_read_register( LORA_REG_NUM_RX_BYTES, &modem_config1_register );
-    uint8_t new_config1_register = ( (lora_config_ptr->lora_bandwidth << 4) | (lora_config_ptr->lora_ecr << 1) | ( 0x01 & modem_config1_register ) ); //TODO: Check datasheet for that last bit
+    uint8_t new_config1_register = ( (lora_config_ptr->lora_bandwidth << 4) | (lora_config_ptr->lora_ecr << 1) | lora_config_ptr->lora_header_mode ); //TODO: Check datasheet for that last bit
 
     // Write new config1 register
     LORA_STATUS write_status3 = lora_write_register( LORA_REG_NUM_RX_BYTES, new_config1_register );
+
+    // Determine register values for the frequency registers
+    uint8_t lora_freq_reg1 = ( lora_config_ptr->lora_frequency <<  8 ) >> 24;
+    uint8_t lora_freq_reg2 = ( lora_config_ptr->lora_frequency << 16 ) >> 24;
+    uint8_t lora_freq_reg3 = ( lora_config_ptr->lora_frequency << 24 ) >> 24;
+
+    // Write the frequncy registers
+    LORA_STATUS write_status4 = lora_write_register( LORA_FREQ_MSB, lora_freq_reg1 );
+    LORA_STATUS write_status5 = lora_write_register( LORA_FREQ_MSD, lora_freq_reg2 );
+    LORA_STATUS write_status6 = lora_write_register( LORA_FREQ_LSB, lora_freq_reg3 );
 
     LORA_STATUS standby_status = lora_set_chip_mode( lora_config_ptr->lora_mode ); // Switch it into standby mode, which is what's convenient.
 

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -128,6 +128,9 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
     // Get initial value of the operation mode register
     uint8_t operation_mode_register;
     LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
+    if( read_status & 0b00000001 != 0b00000001 ) { // Make function automatically fail if chip is not in LoRa mode
+        return LORA_FAIL;
+    }
 
     // Shift the chip mode bits to be the first 3 bits of the sequence
     uint8_t shifted_chip_mode = (chip_mode << 0b00000);
@@ -135,7 +138,7 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
     // Change the value of the chip register to set it to the suggested chip mode
     uint8_t new_opmode_register = (operation_mode_register | shifted_chip_mode);
 
-    // Write new bit
+    // Write new byte
     LORA_STATUS write_status = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
 
     if ( write_status + read_status == 0){
@@ -146,9 +149,23 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
 }
 
 LORA_STATUS lora_init() {
-    return lora_set_chip_mode( LORA_STANDBY_MODE );
-}
+    LORA_STATUS set_sleep_status = lora_set_chip_mode( LORA_SLEEP_MODE ); // Switch to sleep mode to enable LoRa bit (datasheeet page 102)
+    // Get initial value of the operation mode register
+    uint8_t operation_mode_register;
+    LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
+    uint8_t new_opmode_register = ( operation_mode_register | 0b00000001 ); // Toggle the LoRa bit
+    // Write new byte
+    LORA_STATUS write_status = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
 
+    LORA_STATUS standby_status = lora_set_chip_mode( LORA_STANDBY_MODE ); // Switch it into standby mode, which is what's convenient.
+
+    if( set_sleep_status + read_status + write_status + standby_status == 0 ) {
+        return LORA_OK;
+    } else {
+        return LORA_FAIL;
+    }
+}
+/*
 LORA_STATUS lora_transmit( uint8_t data ) {
     LORA_STATUS data_write = lora_write_register( LORA_REG_FIFO_RW, 255 );
 
@@ -165,3 +182,4 @@ LORA_STATUS lora_transmit( uint8_t data ) {
         return LORA_FAIL;
     }
 }
+*/

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -73,7 +73,7 @@ LORA_STATUS lora_read_register( LORA_REGISTER_ADDR lora_register, uint8_t* pRegD
 
     HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_RESET );
     
-    transmit_status = LORA_SPI_Transmit_Single( (lora_register & 0x7F), 0x00 ); // The problem starts here
+    transmit_status = LORA_SPI_Transmit_Single( (lora_register & 0x7F) );
     receive_status = LORA_SPI_Receive( pRegData );
 
     HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_SET );

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -114,34 +114,54 @@ LORA_STATUS lora_get_device_id(uint8_t* buffer_ptr) {
 /*------------------------------------------------------------------------------
  Function to set the mode of the chip
 ------------------------------------------------------------------------------*/
-// void lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
-//     /* chip_mode should be one of the following 3-bit variables defined in lora.h
-//             #define LORA_SLEEP_MODE            0b000
-//             #define LORA_STANDBY_MODE          0b001
-//             #define LORA_FREQ_SYNTH_TX_MODE    0b010
-//             #define LORA_TRANSMIT_MODE         0b011
-//             #define LORA_FREQ_SYNTH_RX_MODE    0b100
-//             #define LORA_RX_CONTINUOUS_MODE    0b101
-//             #define LORA_RX_SINGLE_MODE        0b111
-//     */
-//     // I may give this function a return type in the future to check success of operation.
-//     // Also, may need to be updated based on pin definitions after those are fixed.
+LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
+    /* chip_mode should be one of the following 3-bit variables defined in lora.h
+            #define LORA_SLEEP_MODE            0b000
+            #define LORA_STANDBY_MODE          0b001
+            #define LORA_FREQ_SYNTH_TX_MODE    0b010
+            #define LORA_TRANSMIT_MODE         0b011
+            #define LORA_FREQ_SYNTH_RX_MODE    0b100
+            #define LORA_RX_CONTINUOUS_MODE    0b101            #define LORA_RX_SINGLE_MODE        0b111
+    */
+    // I may give this function a return type in the future to check success of operation.
 
-//     // Pull chip select low
-//     lora_write_cs_pin( GPIO_PIN_SET );
+    // Get initial value of the operation mode register
+    uint8_t operation_mode_register;
+    LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
 
-//     // Get initial value of the operation mode register
-//     uint8_t operation_mode_register = lora_spi_get_register( LORA_REG_OPERATION_MODE );
+    // Shift the chip mode bits to be the first 3 bits of the sequence
+    uint8_t shifted_chip_mode = (chip_mode << 0b00000);
 
-//     // Shift the chip mode bits to be the first 3 bits of the sequence
-//     uint8_t shifted_chip_mode = (chip_mode << 0b00000);
+    // Change the value of the chip register to set it to the suggested chip mode
+    uint8_t new_opmode_register = (operation_mode_register | shifted_chip_mode);
 
-//     // Change the value of the chip register to set it to the suggested chip mode
-//     uint8_t new_opmode_register = (operation_mode_register | chip_mode);
+    // Write new bit
+    LORA_STATUS write_status = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
 
-//     // Write new bit
-//     lora_spi_set_register( LORA_REG_OPERATION_MODE, new_opmode_register );LORA_REG_
+    if ( write_status + read_status == 0){
+        return LORA_OK;
+    } else {
+        return LORA_FAIL;
+    }
+}
 
-//     // Bring chip select back high
-//     lora_write_cs_pin( GPIO_PIN_RESET );
-// }
+LORA_STATUS lora_init() {
+    return lora_set_chip_mode( LORA_STANDBY_MODE );
+}
+
+LORA_STATUS lora_transmit( uint8_t data ) {
+    LORA_STATUS data_write = lora_write_register( LORA_REG_FIFO_RW, 255 );
+
+    LORA_STATUS chip_mode_status = lora_set_chip_mode( LORA_TRANSMIT_MODE );
+
+    uint8_t transmit_status = 0b00000000; // This variable holds the IRQ register, which is checked for transmit done flag
+    while( ( transmit_status & 0b00010000 ) != 0b00010000 ) { // We use this bitmask to check the 4th bit to see if transmission is done
+        lora_read_register( LORA_REG_LORA_STATE_FLAGS, &transmit_status );
+    }
+
+    if ( data_write + chip_mode_status == 0){
+        return LORA_OK;
+    } else {
+        return LORA_FAIL;
+    }
+}

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -35,7 +35,7 @@ LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr ) {
     HAL_StatusTypeDef status;
 
     /* Takes pointer to the read buffer. and puts output there */
-    status = HAL_SPI_Receive( &(LORA_SPI), read_buffer_ptr, 1, 2000 );
+    status = HAL_SPI_Receive( &(LORA_SPI), read_buffer_ptr, 1, LORA_TIMEOUT );
 
     if (status == HAL_OK){
         return LORA_OK;
@@ -49,7 +49,7 @@ LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg ) {
     /* Takes register and data to write (1 byte) and writes that register. */
     // uint8_t transmitBuffer[2] = { reg, data };
     uint8_t transmitBuffer = reg;
-    status = HAL_SPI_Transmit( &(LORA_SPI), &transmitBuffer, 1, 2000);
+    status = HAL_SPI_Transmit( &(LORA_SPI), &transmitBuffer, 1, LORA_TIMEOUT);
 
     if (status == HAL_OK){
         return LORA_OK;
@@ -61,7 +61,7 @@ LORA_STATUS LORA_SPI_Transmit_Double( LORA_REGISTER_ADDR reg, uint8_t data ) {
 
     /* Takes register and data to write (1 byte) and writes that register. */
     uint8_t transmitBuffer[2] = { reg, data };
-    status = HAL_SPI_Transmit( &(LORA_SPI), &transmitBuffer, 1, 2000);
+    status = HAL_SPI_Transmit( &(LORA_SPI), &transmitBuffer, 1, LORA_TIMEOUT);
 
     if (status == HAL_OK){
         return LORA_OK;

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -114,23 +114,21 @@ LORA_STATUS lora_get_device_id(uint8_t* buffer_ptr) {
  Function to set the mode of the chip
 ------------------------------------------------------------------------------*/
 LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
-    /* chip_mode should be one of the following 3-bit variables defined in lora.h
-            #define LORA_SLEEP_MODE            0b000
-            #define LORA_STANDBY_MODE          0b001
-            #define LORA_FREQ_SYNTH_TX_MODE    0b010
-            #define LORA_TRANSMIT_MODE         0b011
-            #define LORA_FREQ_SYNTH_RX_MODE    0b100
-            #define LORA_RX_CONTINUOUS_MODE    0b101            #define LORA_RX_SINGLE_MODE        0b111
-    */
-    // I may give this function a return type in the future to check success of operation.
-
     // Get initial value of the operation mode register
     uint8_t operation_mode_register;
     LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
-    if( read_status & 0b00000001 != 0b00000001 ) { // Make function automatically fail if chip is not in LoRa mode
-        return LORA_FAIL;
+    // if( read_status & 0b00000001 != 0b00000001 ) { // Make function automatically fail if chip is not in LoRa mode
+    //     return LORA_FAIL;
+    // }
+
+    if (read_status != LORA_OK)
+    {
+        // Error handler
     }
 
+    if !( operation_mode_register & (1<<7) ){
+        return LORA_FAIL;
+    }
     // Shift the chip mode bits to be the first 3 bits of the sequence
     uint8_t shifted_chip_mode = (chip_mode << 0b00000);
 

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -123,10 +123,10 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
 
     if (read_status != LORA_OK)
     {
-        // Error handler
+        return LORA_FAIL;
     }
 
-    if !( operation_mode_register & (1<<7) ){
+    if ( !( operation_mode_register & (1<<7) ) ){
         return LORA_FAIL;
     }
 
@@ -147,19 +147,25 @@ LORA_STATUS lora_init( LORA_CONFIG *lora_config_ptr ) {
     LORA_STATUS set_sleep_status = lora_set_chip_mode( LORA_SLEEP_MODE ); // Switch to sleep mode to enable LoRa bit (datasheeet page 102)
     // Get initial value of the operation mode register
     uint8_t operation_mode_register;
-    LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
+    LORA_STATUS read_status1 = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
     uint8_t new_opmode_register;
 
-    if( lora_config_ptr->lora_enabled == LORA_ENABLED  ) {
-        new_opmode_register = ( operation_mode_register | 0b00000001 ); // Toggle the LoRa bit
-    }
+    new_opmode_register = ( operation_mode_register | 0b00000001 ); // Toggle the LoRa bit
 
     // Write new byte
-    LORA_STATUS write_status = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
+    LORA_STATUS write_status1 = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
+
+
+    uint8_t modem_config2_register;
+    LORA_STATUS read_status2 = lora_read_register( LORA_REG_RX_HEADER_INFO, &modem_config2_register );
+
+    uint8_t new_config2_register = modem_config2_register & 0x0F; // Erase spread factor bits
+    uint8_t new_config2_register = ( modem_config2_register | ( lora_config_ptr->lora_spread << 4 ) ); // Set the spread factor
+    LORA_STATUS write_status2 = lora_write_register( LORA_REG_RX_HEADER_INFO, new_config2_register ); // Write new spread factor
 
     LORA_STATUS standby_status = lora_set_chip_mode( lora_config_ptr->lora_mode ); // Switch it into standby mode, which is what's convenient.
 
-    if( set_sleep_status + read_status + write_status + standby_status == 0 ) {
+    if( set_sleep_status + read_status1 + read_status2 + write_status1 + write_status2 + standby_status == 0 ) {
         return LORA_OK;
     } else {
         return LORA_FAIL;

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -117,15 +117,13 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
     // Get initial value of the operation mode register
     uint8_t operation_mode_register;
     LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
-    // if( read_status & 0b00000001 != 0b00000001 ) { // Make function automatically fail if chip is not in LoRa mode
-    //     return LORA_FAIL;
-    // }
 
     if (read_status != LORA_OK)
     {
         return LORA_FAIL;
     }
 
+    // Fail if not in LORA Mode 
     if ( !( operation_mode_register & (1<<7) ) ){
         return LORA_FAIL;
     }

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -43,11 +43,10 @@ LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr ) {
         return LORA_FAIL;
 }
 
-LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg ) {
+LORA_STATUS LORA_SPI_Transmit_Byte( LORA_REGISTER_ADDR reg ) {
     HAL_StatusTypeDef status;
 
     /* Takes register and data to write (1 byte) and writes that register. */
-    // uint8_t transmitBuffer[2] = { reg, data };
     uint8_t transmitBuffer = reg;
     status = HAL_SPI_Transmit( &(LORA_SPI), &transmitBuffer, 1, LORA_TIMEOUT);
 
@@ -56,10 +55,10 @@ LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg ) {
     } else return LORA_FAIL;
 }
 
-LORA_STATUS LORA_SPI_Transmit_Double( LORA_REGISTER_ADDR reg, uint8_t data ) {
+LORA_STATUS LORA_SPI_Transmit_Data( LORA_REGISTER_ADDR reg, uint8_t data ) {
     HAL_StatusTypeDef status;
 
-    /* Takes register and data to write (1 byte) and writes that register. */
+    /* Takes register and data to write and writes that register. */
     uint8_t transmitBuffer[2] = { reg, data };
     status = HAL_SPI_Transmit( &(LORA_SPI), &transmitBuffer, 1, LORA_TIMEOUT);
 
@@ -73,7 +72,7 @@ LORA_STATUS lora_read_register( LORA_REGISTER_ADDR lora_register, uint8_t* pRegD
 
     HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_RESET );
     
-    transmit_status = LORA_SPI_Transmit_Single( (lora_register & 0x7F) );
+    transmit_status = LORA_SPI_Transmit_Byte( (lora_register & 0x7F) );
     receive_status = LORA_SPI_Receive( pRegData );
 
     HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_SET );
@@ -91,7 +90,7 @@ LORA_STATUS lora_write_register( LORA_REGISTER_ADDR lora_register, uint8_t data 
 
     HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_RESET );
 
-    status = LORA_SPI_Transmit_Double( (lora_register | 0x80), data );
+    status = LORA_SPI_Transmit_Data( (lora_register | 0x80), data );
     
     HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_SET );
 

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -129,11 +129,9 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode ) {
     if !( operation_mode_register & (1<<7) ){
         return LORA_FAIL;
     }
-    // Shift the chip mode bits to be the first 3 bits of the sequence
-    uint8_t shifted_chip_mode = (chip_mode << 0b00000);
 
     // Change the value of the chip register to set it to the suggested chip mode
-    uint8_t new_opmode_register = (operation_mode_register | shifted_chip_mode);
+    uint8_t new_opmode_register = (operation_mode_register | chip_mode);
 
     // Write new byte
     LORA_STATUS write_status = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
@@ -151,9 +149,11 @@ LORA_STATUS lora_init( LORA_CONFIG *lora_config_ptr ) {
     uint8_t operation_mode_register;
     LORA_STATUS read_status = lora_read_register( LORA_REG_OPERATION_MODE, &operation_mode_register );
     uint8_t new_opmode_register;
+
     if( lora_config_ptr->lora_enabled == LORA_ENABLED  ) {
         new_opmode_register = ( operation_mode_register | 0b00000001 ); // Toggle the LoRa bit
     }
+
     // Write new byte
     LORA_STATUS write_status = lora_write_register( LORA_REG_OPERATION_MODE, new_opmode_register );
 

--- a/lora/lora.c
+++ b/lora/lora.c
@@ -177,13 +177,13 @@ LORA_STATUS lora_init( LORA_CONFIG *lora_config_ptr ) {
     uint8_t lora_freq_reg3 = ( lora_config_ptr->lora_frequency << 24 ) >> 24;
 
     // Write the frequncy registers
-    LORA_STATUS write_status4 = lora_write_register( LORA_FREQ_MSB, lora_freq_reg1 );
-    LORA_STATUS write_status5 = lora_write_register( LORA_FREQ_MSD, lora_freq_reg2 );
-    LORA_STATUS write_status6 = lora_write_register( LORA_FREQ_LSB, lora_freq_reg3 );
+    LORA_STATUS write_status4 = lora_write_register( LORA_REG_FREQ_MSB, lora_freq_reg1 );
+    LORA_STATUS write_status5 = lora_write_register( LORA_REG_FREQ_MSD, lora_freq_reg2 );
+    LORA_STATUS write_status6 = lora_write_register( LORA_REG_FREQ_LSB, lora_freq_reg3 );
 
     LORA_STATUS standby_status = lora_set_chip_mode( lora_config_ptr->lora_mode ); // Switch it into standby mode, which is what's convenient.
 
-    if( set_sleep_status + read_status1 + read_status2 + read_status3 + write_status1 + write_status2 + write_status3 + standby_status == 0 ) {
+    if( set_sleep_status + read_status1 + read_status2 + read_status3 + write_status1 + write_status2 + write_status3 + write_status4 + write_status5 + write_status6 + standby_status == 0 ) {
         return LORA_OK;
     } else {
         return LORA_FAIL;
@@ -196,6 +196,11 @@ void lora_reset() {
     HAL_GPIO_WritePin(LORA_RST_GPIO_PORT, LORA_RST_PIN, GPIO_PIN_SET);   // Pull High
     HAL_Delay(10);  // Wait for SX1278 to stabilize
 }
+
+uint32_t lora_helper_mhz_to_reg_val( uint32_t mhz_freq ) {
+    return ( (2^19) * mhz_freq * 10^6 )/( 32 * 10^6 );
+}
+
 /*
 LORA_STATUS lora_transmit( uint8_t data ) {
     LORA_STATUS data_write = lora_write_register( LORA_REG_FIFO_RW, 255 );

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -109,10 +109,33 @@ typedef enum LORA_SPREADING_FACTOR {
    LORA_SPREAD_12 = 12
 } LORA_SPREADING_FACTOR;
 
+/* Datasheet page 106 */
+typedef enum LORA_BANDWIDTH {
+   LORA_BANDWIDTH_7_8_KHZ   = 0x00,
+   LORA_BANDWIDTH_10_4_KHZ  = 0x01,
+   LORA_BANDWIDTH_15_6_KHZ  = 0x02,
+   LORA_BANDWIDTH_20_8_KHZ  = 0x03,
+   LORA_BANDWIDTH_31_25_KHZ = 0x04,
+   LORA_BANDWIDTH_41_7_KHZ  = 0x05,
+   LORA_BANDWIDTH_62_5_KHZ  = 0x06,
+   LORA_BANDWIDTH_125_KHZ   = 0x07,
+   LORA_BANDWIDTH_250_KHZ   = 0x08,
+   LORA_BANDWIDTH_500_KHZ   = 0x09
+} LORA_BANDWIDTH;
+
+typedef enum LORA_ERROR_CODING {
+   LORA_ECR_4_5 = 0x01,
+   LORA_ECR_4_6 = 0x02,
+   LORA_ECR_4_7 = 0x03,
+   LORA_ECR_4_8 = 0x04
+} LORA_ERROR_CODING;
+
 /* LORA CONFIG SETTINGS */
 typedef struct _LORA_CONFIG {
    LORA_CHIPMODE lora_mode; // Current LORA Chipmode
    LORA_SPREADING_FACTOR lora_spread; // LoRa Spread factor
+   LORA_BANDWIDTH lora_bandwidth; // Signal bandwith
+   LORA_ERROR_CODING lora_ecr; // Data Error coding
 } LORA_CONFIG;
 
 LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -48,11 +48,6 @@ typedef enum LORA_STATUS {
    LORA_RECEIVE_FAIL
 } LORA_STATUS;
 
-typedef enum LORA_ENABLE {
-   LORA_ENABLED,
-   LORA_DISABLED
-} LORA_ENABLE;
-
 /* Radio register addresses from datasheet (https://www.mouser.com/datasheet/2/975/1463993415RFM95_96_97_98W-1858106.pdf)
    Note: as we are using LoRa, the FSK opcodes are not included*/
 typedef enum LORA_REGISTER_ADDR {
@@ -103,10 +98,21 @@ typedef enum LORA_REGISTER_ADDR {
    LORA_REG_AGC_THRESHOLD_4            = 0x64
 } LORA_REGISTER_ADDR;
 
+/* Datasheet page 107 */
+typedef enum LORA_SPREADING_FACTOR {
+   LORA_SPREAD_6 = 6,
+   LORA_SPREAD_7 = 7,
+   LORA_SPREAD_8 = 8,
+   LORA_SPREAD_9 = 9,
+   LORA_SPREAD_10 = 10,
+   LORA_SPREAD_11 = 11,
+   LORA_SPREAD_12 = 12
+} LORA_SPREADING_FACTOR;
+
 /* LORA CONFIG SETTINGS */
 typedef struct _LORA_CONFIG {
-   LORA_ENABLE lora_enabled; // LORA enablement status
    LORA_CHIPMODE lora_mode; // Current LORA Chipmode
+   LORA_SPREADING_FACTOR lora_spread; // LoRa Spread factor
 } LORA_CONFIG;
 
 LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -110,9 +110,9 @@ typedef struct _LORA_CONFIG {
 
 LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );
 
-LORA_STATUS LORA_SPI_Transmit_Double( LORA_REGISTER_ADDR reg, uint8_t data );
+LORA_STATUS LORA_SPI_Transmit_Buffer( LORA_REGISTER_ADDR reg, uint8_t data );
 
-LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg );
+LORA_STATUS LORA_SPI_Transmit_Byte( LORA_REGISTER_ADDR reg );
 
 LORA_STATUS lora_read_register( LORA_REGISTER_ADDR lora_register, uint8_t* regData);
 

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -130,12 +130,21 @@ typedef enum LORA_ERROR_CODING {
    LORA_ECR_4_8 = 0x04
 } LORA_ERROR_CODING;
 
+typedef enum LORA_HEADER_MODE {// You can see this on 106 - what this actually means is on pages 26 and 27
+   LORA_IMPLICIT_HEADER = 0b1,
+   LORA_EXPLICIT_HEADER = 0b0
+} LORA_HEADER_MODE;
+
 /* LORA CONFIG SETTINGS */
 typedef struct _LORA_CONFIG {
    LORA_CHIPMODE lora_mode; // Current LORA Chipmode
    LORA_SPREADING_FACTOR lora_spread; // LoRa Spread factor
    LORA_BANDWIDTH lora_bandwidth; // Signal bandwith
    LORA_ERROR_CODING lora_ecr; // Data Error coding
+   LORA_HEADER_MODE lora_header_mode; // LORA Header mode
+   uint32_t lora_frequency; // The LORA carrier frequency. This is NOT directly in megahertz. (See datasheet page 103)
+   // To convert, use the formula (2^19 * x)/(32 * 10^6)
+   // This library provides a helper function 
 } LORA_CONFIG;
 
 LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );
@@ -155,6 +164,12 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode );
 LORA_STATUS lora_init();
 
 void lora_reset();
+
+
+// Convert a human-readable frequency to the unit used internally by the modem
+uint32_t lora_helper_mhz_to_reg_val( uint32_t mhz_freq ) {
+   return ( (2^19) * x )/( 32 * 10^6 );
+}
 
 // LORA_STATUS lora_transmit( uint8_t data );
 

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -97,7 +97,9 @@ typedef enum LORA_REGISTER_ADDR {
 
 LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );
 
-LORA_STATUS LORA_SPI_Transmit( LORA_REGISTER_ADDR reg, uint8_t data );
+LORA_STATUS LORA_SPI_Transmit_Double( LORA_REGISTER_ADDR reg, uint8_t data );
+
+LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg, uint8_t data );
 
 LORA_STATUS lora_read_register( LORA_REGISTER_ADDR lora_register, uint8_t* regData);
 

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -167,9 +167,7 @@ void lora_reset();
 
 
 // Convert a human-readable frequency to the unit used internally by the modem
-uint32_t lora_helper_mhz_to_reg_val( uint32_t mhz_freq ) {
-   return ( (2^19) * x * 10^6 )/( 32 * 10^6 );
-}
+uint32_t lora_helper_mhz_to_reg_val( uint32_t mhz_freq );
 
 // LORA_STATUS lora_transmit( uint8_t data );
 

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -30,13 +30,14 @@ they are commented out for now and will be uncommented as they're needed.
 #define LORA_TIMEOUT                2000
 
 typedef enum LORA_CHIPMODE {
-   LORA_SLEEP_MODE = 0b000,
-   LORA_STANDBY_MODE = 0b001,
-   LORA_FREQ_SYNTH_TX_MODE = 0b010,
-   LORA_TRANSMIT_MODE = 0b011,
-   LORA_FREQ_SYNTH_RX_MODE = 0b100,
-   LORA_RX_CONTINUOUS_MODE = 0b101,
-   LORA_RX_SINGLE_MODE = 0b111,
+   LORA_SLEEP_MODE = 0x00,
+   LORA_STANDBY_MODE = 0x01,
+   LORA_FREQ_SYNTH_TX_MODE = 0x02,
+   LORA_TRANSMIT_MODE = 0x03,
+   LORA_FREQ_SYNTH_RX_MODE = 0x04,
+   LORA_RX_CONTINUOUS_MODE = 0x05,
+   LORA_RX_SINGLE_MODE = 0x06,
+   LORA_RX_CAD         = 0x07
 } LORA_CHIPMODE;
 
 typedef enum LORA_STATUS {

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -168,7 +168,7 @@ void lora_reset();
 
 // Convert a human-readable frequency to the unit used internally by the modem
 uint32_t lora_helper_mhz_to_reg_val( uint32_t mhz_freq ) {
-   return ( (2^19) * x )/( 32 * 10^6 );
+   return ( (2^19) * x * 10^6 )/( 32 * 10^6 );
 }
 
 // LORA_STATUS lora_transmit( uint8_t data );

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -27,6 +27,8 @@ they are commented out for now and will be uncommented as they're needed.
 #define LORA_OPERATION_RESERVED    0b00
 */
 
+#define LORA_TIMEOUT                2000
+
 typedef enum LORA_CHIPMODE {
    LORA_SLEEP_MODE = 0b000,
    LORA_STANDBY_MODE = 0b001,

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -45,6 +45,11 @@ typedef enum LORA_STATUS {
    LORA_RECEIVE_FAIL
 } LORA_STATUS;
 
+typedef enum LORA_ENABLE {
+   LORA_ENABLED,
+   LORA_DISABLED
+} LORA_ENABLE;
+
 /* Radio register addresses from datasheet (https://www.mouser.com/datasheet/2/975/1463993415RFM95_96_97_98W-1858106.pdf)
    Note: as we are using LoRa, the FSK opcodes are not included*/
 typedef enum LORA_REGISTER_ADDR {
@@ -95,6 +100,12 @@ typedef enum LORA_REGISTER_ADDR {
    LORA_REG_AGC_THRESHOLD_4            = 0x64
 } LORA_REGISTER_ADDR;
 
+/* LORA CONFIG SETTINGS */
+typedef struct _LORA_CONFIG {
+   LORA_ENABLE lora_enabled; // LORA enablement status
+   LORA_CHIPMODE lora_mode; // Current LORA Chipmode
+} LORA_CONFIG;
+
 LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );
 
 LORA_STATUS LORA_SPI_Transmit_Double( LORA_REGISTER_ADDR reg, uint8_t data );
@@ -111,6 +122,8 @@ LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode );
 
 LORA_STATUS lora_init();
 
-LORA_STATUS lora_transmit( uint8_t data );
+void lora_reset();
+
+// LORA_STATUS lora_transmit( uint8_t data );
 
 #endif

--- a/lora/lora.h
+++ b/lora/lora.h
@@ -99,12 +99,18 @@ LORA_STATUS LORA_SPI_Receive( uint8_t* read_buffer_ptr );
 
 LORA_STATUS LORA_SPI_Transmit_Double( LORA_REGISTER_ADDR reg, uint8_t data );
 
-LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg, uint8_t data );
+LORA_STATUS LORA_SPI_Transmit_Single( LORA_REGISTER_ADDR reg );
 
 LORA_STATUS lora_read_register( LORA_REGISTER_ADDR lora_register, uint8_t* regData);
 
 LORA_STATUS lora_write_register( LORA_REGISTER_ADDR lora_register, uint8_t data );
 
 LORA_STATUS lora_get_device_id(uint8_t* buffer_ptr);
+
+LORA_STATUS lora_set_chip_mode( LORA_CHIPMODE chip_mode );
+
+LORA_STATUS lora_init();
+
+LORA_STATUS lora_transmit( uint8_t data );
 
 #endif


### PR DESCRIPTION
This improves the lora_init function so it should actually work, adding the required sleep mode to set the LORA bit. It then brings it into standby mode.

Chipmode now checks if the LORA bit is set, and fails otherwise.

This might not be able to be merged immediately - I need to consider whether a chip config struct is needed or whether the chip is simple enough that I can just have a simple init function.