### PR TITLE
Add Error_Handler backwards compatibility

### DIFF
--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -38,6 +38,7 @@ extern "C" {
  Constants 
 ------------------------------------------------------------------------------*/
 #define TEXT_MESSAGE_LENGTH 72
+#define Error_Handler( a ) error_fail_fast( a ) /* backwards compatible */
 
 /*------------------------------------------------------------------------------
  Typdefs 


### PR DESCRIPTION
## Description
Older platforms like the ground station and liquids use a different error handler. This macro provides the functionality of our modern error handler.

### Issue Link
Parent: https://github.com/SunDevilRocketry/Engine-Controller-Firmware/pull/44

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code