### PR TITLE
Make GPS parse work with emulator

### DIFF
--- a/gps/gps.c
+++ b/gps/gps.c
@@ -283,7 +283,7 @@ void GPS_parse(GPS_DATA* gps_ptr, char *GPSstrParse){
 /* Get message type */
 char token[8]; // Needs to be 8 chars for memory alignment
 strncpy(token, GPSstrParse, 6);
-token[7] = '\0';
+token[6] = '\0';
 int idx = 7; /* Skips "$GPXXX,"*/
 
 /* Parse by message type */


### PR DESCRIPTION
## Description
GPS_parse doesn't like the string it gets unless I set this bit to \0 instead

### Issue Link


### Testing
- [x] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code