### PR TITLE
add IT tx function for rs485

### DIFF
--- a/rs485/rs485.c
+++ b/rs485/rs485.c
@@ -137,6 +137,55 @@ else
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   *
+* 		rs485_transmit_IT                                                         *
+*                                                                              *
+* DESCRIPTION:                                                                 *
+* 		transmits a buffer of bytes over RS485                                 *
+*                                                                              *
+*******************************************************************************/
+RS485_STATUS rs485_transmit_IT
+	(
+    void*    tx_buffer_ptr,   /* Pointer to buffer data    */
+	size_t   buffer_size      /* Number of bytes in buffer */
+	)
+{
+/*------------------------------------------------------------------------------
+ Local Variables
+------------------------------------------------------------------------------*/
+HAL_StatusTypeDef hal_status;    /* Return codes from HAL */
+
+
+/*------------------------------------------------------------------------------
+ Initializations 
+------------------------------------------------------------------------------*/
+hal_status = HAL_OK;
+
+
+/*------------------------------------------------------------------------------
+ API Function Implementation 
+------------------------------------------------------------------------------*/
+
+/* Transmit byte */
+hal_status = HAL_UART_Transmit_IT( &( RS485_HUART ),
+                                tx_buffer_ptr  , 
+                                buffer_size );
+
+/* Return HAL status */
+if ( hal_status != HAL_OK )
+	{
+	return RS485_ERROR;
+	}
+else
+	{
+	return RS485_OK;
+	}
+
+} /* rs485_transmit_IT */
+
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   *
 * 		rs485_receieve_byte                                                    *
 *                                                                              *
 * DESCRIPTION:                                                                 *

--- a/rs485/rs485.h
+++ b/rs485/rs485.h
@@ -63,6 +63,13 @@ RS485_STATUS rs485_transmit
 	uint32_t timeout          /* Timeout in ms             */
 	);
 
+/* transmits a buffer of bytes in interrupt mode */
+RS485_STATUS rs485_transmit_IT
+	(
+    void*    tx_buffer_ptr,   /* Pointer to buffer data    */
+	size_t   buffer_size      /* Number of bytes in buffer */
+	);
+
 /* Receives a byte from the RS485 interface */
 RS485_STATUS rs485_receive_byte 
 	(


### PR DESCRIPTION
## Description
Adds a transmission function for RS485 in interrupt mode.

### Issue Link
parent: https://github.com/SunDevilRocketry/Engine-Controller-Firmware/pull/47

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

N/A. Waiting on integ test from @niekky 

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code