### PR TITLE
fix: Compile out IRQ enable/disable in emulator (inline asm my behated)

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -61,7 +61,9 @@ void disable_irq
     void
     ) 
 {
+#ifndef EMULATOR
 __disable_irq();
+#endif
 } /* disable_irq */
 
 
@@ -79,7 +81,9 @@ void enable_irq
     void
     ) 
 {
+#ifndef EMULATOR
 __enable_irq();
+#endif
 } /* enable_irq */
 
 


### PR DESCRIPTION
## Description
Compile out IRQ enable/disable in emulator to fix an assembler error.

### Issue Link
Parent; https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/234

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code