### PR TITLE
mod/error_sdr: Add ERROR_USB_CDC_INIT_ERROR

### DIFF
--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -105,6 +105,7 @@ typedef enum _ERROR_CODE
     ERROR_SENSOR_FORMAT_ERROR          , /* unused                            */
     ERROR_INVALID_STATE_ERROR          , /* FSM has reached an invalid state  */
     ERROR_CONFIG_VALIDITY_ERROR        , /* Loaded configuration is invalid   */
+    ERROR_USB_CDC_INIT_ERROR           , /* Error initializing USB CDC device  */
     ERROR_IGNITION_CONTINUITY_ERROR      /* No continuity on IGN terminals    */
     } ERROR_CODE;
 


### PR DESCRIPTION
## Description
Adds `ERROR_USB_CDC_INIT_ERROR` to the error handling module. This error code is required by the USB driver for proper error handling during CDC initialization failures.

### Issue Link
This PR is a **child dependency** of Issue SunDevilRocketry/driver#4 (USB: Initial R3 Driver Implementation).

This error code is required for the USB driver to properly handle CDC initialization failures as requested in Issue SunDevilRocketry/driver#4.


### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (N/A - only error constant addition)
- [ ] Integration test performed - N/A, error definition only

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code