### PR TITLE
Fix tdelta calculations for imu and baro

### DIFF
--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1431,6 +1431,25 @@ return SENSOR_OK;
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   *
+* 		sensor_initialize_tick                                                 *
+*                                                                              *
+* DESCRIPTION:                                                                 *
+*       Set the initial values for baro and imu tick at calibration            *
+*                                                                              *
+*******************************************************************************/
+void sensor_initialize_tick
+	(
+	void
+	)
+{
+baro_velo_tick = get_us_tick();
+imu_velo_tick = baro_velo_tick;
+
+}
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   *
 * 		sensor_conv_imu                                                   *
 *                                                                              *
 * DESCRIPTION:                                                                 *
@@ -1613,7 +1632,7 @@ void sensor_imu_velo(IMU_DATA* imu_data){
 	
 	uint64_t current_tick = get_us_tick();
 	uint64_t imu_tdelta = current_tick - imu_velo_tick;
-	ts_delta = imu_tdelta / 1000000.0;
+	ts_delta = imu_tdelta / MICROSEC_PER_SEC;
 
 	// Calculate 3 velocity vectors using motion equations
 	velo_x = velo_x_prev + accel_x*ts_delta;
@@ -1661,7 +1680,7 @@ void sensor_baro_velo(SENSOR_DATA* sen_data)
 	// pressure *= 6894.76;
 	uint64_t current_tick = get_us_tick();
 	uint64_t baro_tdelta = current_tick - baro_velo_tick;
-	float ts_delta = baro_tdelta / 1000000.0;
+	float ts_delta = baro_tdelta / MICROSEC_PER_SEC;
 
 	// calc altitude
 	float PRESSURE_SEA_LEVEL = 101325;

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1454,7 +1454,7 @@ void sensor_initialize_tick
 baro_velo_tick = get_us_tick();
 imu_velo_tick = baro_velo_tick;
 
-}
+} /* sensor_initialize_tick */
 
 
 
@@ -1477,7 +1477,7 @@ velo_x_prev = 0;
 velo_y_prev = 0;
 velo_z_prev = 0;
 
-}
+} /* sensor_reset_velo */
 
 
 /*******************************************************************************

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1598,7 +1598,7 @@ float sensor_gyro_conv(uint16_t readout){
 * 		sensor_imu_velo                                                        *
 *                                                                              *
 * DESCRIPTION:                                                                 *
-*       Calculate the velocity depending on accel 								*
+*       Calculate the velocity depending on accel 							   *
 *                                                                              *
 *******************************************************************************/
 float velo_x_prev, velo_y_prev, velo_z_prev = 0.0;
@@ -1607,24 +1607,26 @@ void sensor_imu_velo(IMU_DATA* imu_data){
 
 	float accel_x = imu_data->imu_converted.accel_x;
 	float accel_y = imu_data->imu_converted.accel_y;
-	float accel_z = imu_data->imu_converted.accel_z; /* NA TMP: for some reason this number is really high */
+	float accel_z = imu_data->imu_converted.accel_z;
 
 	float ts_delta;
 	
 	uint64_t current_tick = get_us_tick();
-	uint64_t imu_tdelta = current_tick - baro_velo_tick;
-	// if ( baro_velo_tick != 0 ) // Could discard first value completely
-		ts_delta = imu_tdelta / 1000000.0;
-	// else
-	// 	ts_delta = 0; 
+	uint64_t imu_tdelta = current_tick - imu_velo_tick;
+	ts_delta = imu_tdelta / 1000000.0;
 
 	// Calculate 3 velocity vectors using motion equations
 	velo_x = velo_x_prev + accel_x*ts_delta;
 	velo_y = velo_y_prev + accel_y*ts_delta;
 	velo_z = velo_z_prev + accel_z*ts_delta;
-	
+
 	// Calculate the velocity scalar
 	velocity = sqrtf(powf(velo_x, 2.0) + powf(velo_y, 2.0) + powf(velo_z, 2.0));
+
+	/* Update state estimations*/
+	imu_data->state_estimate.velo_x = velo_x;
+	imu_data->state_estimate.velo_y = velo_y;
+	imu_data->state_estimate.velo_z = velo_z;
 
 	imu_data->state_estimate.velocity = velocity;
 
@@ -1657,10 +1659,6 @@ void sensor_baro_velo(SENSOR_DATA* sen_data)
 	float temp = sen_data->baro_temp;
 	// conv pressure to pascal for equation
 	// pressure *= 6894.76;
-	/* NA: weird stuff still happens for the first frame because there's a large delay between
-	   when the FC is powered on and the first tick measured here. We might want to consider setting 
-	   the baro_velo_tick and imu_velo_tick to the current tick when we enter the fsm.
-	*/
 	uint64_t current_tick = get_us_tick();
 	uint64_t baro_tdelta = current_tick - baro_velo_tick;
 	float ts_delta = baro_tdelta / 1000000.0;

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -75,6 +75,7 @@
 static SENSOR_DATA_SIZE_OFFSETS sensor_size_offsets_table[ NUM_SENSORS ];
 
 /* Timing (sensors) */
+extern volatile uint32_t tdelta, previous_time;
 uint64_t baro_velo_tick = 0;
 uint64_t imu_velo_tick = 0;
 
@@ -499,6 +500,9 @@ switch ( subcommand )
 				}
 		#endif
 
+		// Reset start time
+		previous_time = HAL_GetTick();
+
 		/* Start polling sensors */
 		while ( sensor_poll_cmd != SENSOR_POLL_STOP )
 			{
@@ -541,6 +545,8 @@ switch ( subcommand )
 				/* Poll Sensors */
 				case SENSOR_POLL_REQUEST:
 					{
+					tdelta = HAL_GetTick() - previous_time;
+					previous_time = HAL_GetTick();
 					sensor_status = sensor_poll( &sensor_data    , 
 												 &poll_sensors[0],
 												 num_sensors );
@@ -569,6 +575,9 @@ switch ( subcommand )
 				/* STOP Executtion */
 				case SENSOR_POLL_STOP:
 					{
+					// Reset timing
+					previous_time = 0;
+					tdelta = 0;
 					break;
 					} /* case SENSOR_POLL_STOP */
 

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1456,6 +1456,30 @@ imu_velo_tick = baro_velo_tick;
 
 }
 
+
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   *
+* 		sensor_reset_velo                                                      *
+*                                                                              *
+* DESCRIPTION:                                                                 *
+*       Reset velocity values to prevent accumulation of drift                 *
+*                                                                              *
+*******************************************************************************/
+void sensor_reset_velo
+	(
+	void
+	)
+{
+velo_prev = 0;
+velo_x_prev = 0;
+velo_y_prev = 0;
+velo_z_prev = 0;
+
+}
+
+
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   *

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -50,6 +50,7 @@
 #if defined( FLIGHT_COMPUTER )
 	#include "imu.h"
 	#include "baro.h"
+	#include "timer.h"
 #elif defined( FLIGHT_COMPUTER_LITE )
 	#include "baro.h"
 #endif
@@ -72,7 +73,10 @@
 
 /* Hash table of sensor readout sizes and offsets */
 static SENSOR_DATA_SIZE_OFFSETS sensor_size_offsets_table[ NUM_SENSORS ];
-extern volatile uint32_t tdelta, previous_time;
+
+/* Timing (sensors) */
+uint64_t baro_velo_tick = 0;
+uint64_t imu_velo_tick = 0;
 
 #ifdef FLIGHT_COMPUTER
 extern GPS_DATA gps_data;
@@ -495,9 +499,6 @@ switch ( subcommand )
 				}
 		#endif
 
-		// Reset start time
-		previous_time = HAL_GetTick();
-
 		/* Start polling sensors */
 		while ( sensor_poll_cmd != SENSOR_POLL_STOP )
 			{
@@ -540,8 +541,6 @@ switch ( subcommand )
 				/* Poll Sensors */
 				case SENSOR_POLL_REQUEST:
 					{
-					tdelta = HAL_GetTick() - previous_time;
-					previous_time = HAL_GetTick();
 					sensor_status = sensor_poll( &sensor_data    , 
 												 &poll_sensors[0],
 												 num_sensors );
@@ -570,9 +569,6 @@ switch ( subcommand )
 				/* STOP Executtion */
 				case SENSOR_POLL_STOP:
 					{
-					// Reset timing
-					previous_time = 0;
-					tdelta = 0;
 					break;
 					} /* case SENSOR_POLL_STOP */
 
@@ -1611,9 +1607,16 @@ void sensor_imu_velo(IMU_DATA* imu_data){
 
 	float accel_x = imu_data->imu_converted.accel_x;
 	float accel_y = imu_data->imu_converted.accel_y;
-	float accel_z = imu_data->imu_converted.accel_z;
+	float accel_z = imu_data->imu_converted.accel_z; /* NA TMP: for some reason this number is really high */
 
-	float ts_delta = tdelta / 1000.0;
+	float ts_delta;
+	
+	uint64_t current_tick = get_us_tick();
+	uint64_t imu_tdelta = current_tick - baro_velo_tick;
+	// if ( baro_velo_tick != 0 ) // Could discard first value completely
+		ts_delta = imu_tdelta / 1000000.0;
+	// else
+	// 	ts_delta = 0; 
 
 	// Calculate 3 velocity vectors using motion equations
 	velo_x = velo_x_prev + accel_x*ts_delta;
@@ -1631,6 +1634,9 @@ void sensor_imu_velo(IMU_DATA* imu_data){
 	velo_z_prev = velo_z;
 
 	imu_data->state_estimate.position = 0; //TODO: Implement position
+
+	imu_velo_tick = current_tick;
+
 }
 
 /*******************************************************************************
@@ -1651,7 +1657,13 @@ void sensor_baro_velo(SENSOR_DATA* sen_data)
 	float temp = sen_data->baro_temp;
 	// conv pressure to pascal for equation
 	// pressure *= 6894.76;
-	float ts_delta = tdelta / 1000.0;
+	/* NA: weird stuff still happens for the first frame because there's a large delay between
+	   when the FC is powered on and the first tick measured here. We might want to consider setting 
+	   the baro_velo_tick and imu_velo_tick to the current tick when we enter the fsm.
+	*/
+	uint64_t current_tick = get_us_tick();
+	uint64_t baro_tdelta = current_tick - baro_velo_tick;
+	float ts_delta = baro_tdelta / 1000000.0;
 
 	// calc altitude
 	float PRESSURE_SEA_LEVEL = 101325;
@@ -1668,6 +1680,8 @@ void sensor_baro_velo(SENSOR_DATA* sen_data)
 
 	sen_data->baro_alt = alt;
 	sen_data->baro_velo = velocity;
+
+	baro_velo_tick = current_tick;
 
 }
 

--- a/sensor/sensor.h
+++ b/sensor/sensor.h
@@ -65,6 +65,7 @@ Includes
 	#define NUM_SENSORS         ( 38   )
 	// #define IMU_DATA_SIZE       ( 20   )
 	#define SENSOR_DATA_SIZE	( 128   )
+	#define MICROSEC_PER_SEC	( 1000000.0 )
 #elif defined( ENGINE_CONTROLLER )
 	/* General */
 	#define NUM_SENSORS         ( 10   )
@@ -290,6 +291,7 @@ SENSOR_STATUS sensor_dump
     );
 
 #ifdef FLIGHT_COMPUTER
+void sensor_initialize_tick(void);
 void sensor_body_state(IMU_DATA* imu_data);
 void sensor_imu_velo(IMU_DATA* imu_data);
 void sensor_conv_imu(IMU_DATA* imu_data, IMU_RAW* imu_raw);

--- a/sensor/sensor.h
+++ b/sensor/sensor.h
@@ -65,7 +65,6 @@ Includes
 	#define NUM_SENSORS         ( 38   )
 	// #define IMU_DATA_SIZE       ( 20   )
 	#define SENSOR_DATA_SIZE	( 128   )
-	#define MICROSEC_PER_SEC	( 1000000.0 )
 #elif defined( ENGINE_CONTROLLER )
 	/* General */
 	#define NUM_SENSORS         ( 10   )

--- a/sensor/sensor.h
+++ b/sensor/sensor.h
@@ -291,6 +291,7 @@ SENSOR_STATUS sensor_dump
 
 #ifdef FLIGHT_COMPUTER
 void sensor_initialize_tick(void);
+void sensor_reset_velo(void);
 void sensor_body_state(IMU_DATA* imu_data);
 void sensor_imu_velo(IMU_DATA* imu_data);
 void sensor_conv_imu(IMU_DATA* imu_data, IMU_RAW* imu_raw);


### PR DESCRIPTION
## Description
This adds ticks for baro and imu which replace the broken tdelta in the app layer. Although this means we now get values, they aren't very accurate because imu velo drifts a lot and needs to be zeroed at some point, and baro velo is too sensitive to high frequency jitter.

[extracted_data.csv](https://github.com/user-attachments/files/26809384/extracted_data.csv) - see velocity, velo x,y,z, and baro velo. The values of baro velo are basically useless though.


### Issue Link
#102 - Maybe we should just finally lay this issue to rest and open a new ticket to address the other problems.

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code