### PR TITLE
fix: bad iterator size in error callback table lookups

### DIFF
--- a/error_sdr/error_sdr.c
+++ b/error_sdr/error_sdr.c
@@ -286,7 +286,7 @@ static volatile ERROR_CALLBACK* callback_table_lookup
     volatile ERROR_CODE error_code
     )
 {
-for( uint8_t i = 0; i < error_callback_table_size; i++ )
+for( uint16_t i = 0; i < error_callback_table_size; i++ )
     {
     if( error_callback_table[i].error_code == error_code )
         {


### PR DESCRIPTION
## Description
Simple fix for security alert https://github.com/SunDevilRocketry/Flight-Computer-Firmware/security/code-scanning/67 in FC rev 2.

### Issue Link
Closes https://github.com/SunDevilRocketry/mod/issues/122.

### Testing
- [X] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Rev 2's SW integration tests for the error system still pass.

<img width="587" height="288" alt="image" src="https://github.com/user-attachments/assets/60940c94-3d4e-4c9f-aa03-9cdd71d16e76" />

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code