### PR TITLE
Use signed int for acc and gyro conv

### DIFF
--- a/math_sdr/math_sdr.h
+++ b/math_sdr/math_sdr.h
@@ -57,6 +57,7 @@ _Static_assert( sizeof(ST_UID_TYPE) == 12, "ST_UID_TYPE packing incorrect." );
 
 /* Constants */
 #define COMP_ALPHA 0.98f /* Used in sensor fusion */
+#define GRAVITY 9.8f
 
 /*******************************************************************************
 *                                                                              *

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1606,8 +1606,8 @@ float sensor_gyro_conv
 	int16_t readout
 	)
 {
-float gyro_setting = 2000.0f;
-float gyro_sens = 65535.0f / ( 2.0f * gyro_setting );
+const float gyro_setting = 2000.0f;
+const float gyro_sens = 65535.0f / ( 2.0f * gyro_setting );
 
 return readout / gyro_sens;
 

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1578,22 +1578,18 @@ imu_data->state_estimate.yaw_rate    = yaw_rate;
 *       Convert Acc readouts to m/s^2                                          *
 *                                                                              *
 *******************************************************************************/
-float sensor_acc_conv(uint16_t readout){
-	// sign check
-	uint16_t num_sign = (readout & (0x8000)) >> 0xF;
-	int8_t sign_bit = 1;
+float sensor_acc_conv
+	(
+	int16_t readout
+	)
+{
+/* Scale readout value from integer limits to +/- the g_setting * g */
+const uint8_t g_setting = 16;
+const float g = 9.8f;
+const float accel_step = (2.0f * g_setting * g ) / 65535.0f;
 
-	if (num_sign == 1){
-		readout = ((uint16_t) ( ( ~readout + 1 ) & (0xFFFF) ));
-		sign_bit = -1;
-	}
+return accel_step * readout;
 
-	// Convert to accel
-	uint8_t g_setting = 16;
-	float g = 9.8;
-	float accel_step = 2*g_setting*g/65535.0;
-
-	return sign_bit*(accel_step*readout);
 }
 
 /*******************************************************************************
@@ -1605,20 +1601,16 @@ float sensor_acc_conv(uint16_t readout){
 *       Convert gyro readouts to deg/s                                         *
 *                                                                              *
 *******************************************************************************/
-float sensor_gyro_conv(uint16_t readout){
-	// sign check
-	uint16_t num_sign = (readout & (0x8000)) >> 0xF;
-	int8_t sign_bit = 1;
-	if (num_sign == 1){
-		readout = ((uint16_t) ( ( ~readout + 1 ) & (0xFFFF) ));
-		sign_bit = -1;
-	}
+float sensor_gyro_conv
+	(
+	int16_t readout
+	)
+{
+float gyro_setting = 2000.0f;
+float gyro_sens = 65535.0f / ( 2.0f * gyro_setting );
 
-	// Convert to accel
-	float gyro_setting = 2000.0;
-	float gyro_sens = 65535.0 / (2*gyro_setting);
-	
-	return sign_bit * (readout / gyro_sens);
+return readout / gyro_sens;
+
 }
 
 /*******************************************************************************

--- a/sensor/sensor.c
+++ b/sensor/sensor.c
@@ -1583,14 +1583,12 @@ float sensor_acc_conv
 	int16_t readout
 	)
 {
-/* Scale readout value from integer limits to +/- the g_setting * g */
-const uint8_t g_setting = 16;
-const float g = 9.8f;
-const float accel_step = (2.0f * g_setting * g ) / 65535.0f;
+/* Scale readout value from integer limits to +/- the accelerometer measurement range */
+const float accel_step = (2.0f * ACCEL_G_RANGE * GRAVITY ) / UINT16_MAX;
 
 return accel_step * readout;
-
-}
+ 
+} /* sensor_acc_conv */
 
 /*******************************************************************************
 *                                                                              *
@@ -1606,12 +1604,11 @@ float sensor_gyro_conv
 	int16_t readout
 	)
 {
-const float gyro_setting = 2000.0f;
-const float gyro_sens = 65535.0f / ( 2.0f * gyro_setting );
+const float gyro_sens = UINT16_MAX / ( 2.0f * GYRO_RANGE );
 
 return readout / gyro_sens;
 
-}
+} /* sensor_gyro_conv */
 
 /*******************************************************************************
 *                                                                              *

--- a/sensor/sensor.h
+++ b/sensor/sensor.h
@@ -295,8 +295,8 @@ void sensor_reset_velo(void);
 void sensor_body_state(IMU_DATA* imu_data);
 void sensor_imu_velo(IMU_DATA* imu_data);
 void sensor_conv_imu(IMU_DATA* imu_data, IMU_RAW* imu_raw);
-float sensor_acc_conv(uint16_t readout);
-float sensor_gyro_conv(uint16_t readout);
+float sensor_acc_conv(int16_t readout);
+float sensor_gyro_conv(int16_t readout);
 void sensor_baro_velo(SENSOR_DATA* sensor_data_ptr);
 #endif
 

--- a/sensor/sensor.h
+++ b/sensor/sensor.h
@@ -60,6 +60,11 @@ Includes
 /* Max allowed number of sensors for polling */
 #define SENSOR_MAX_NUM_POLL     ( 5    )
 
+#if defined( A0002_REV2 )
+	#define ACCEL_G_RANGE ( 16 ) /* Accelerometer measurement range */
+	#define GYRO_RANGE ( 2000 )  /* Gyroscope sensitivity in degrees/sec */
+#endif
+
 #if   defined( FLIGHT_COMPUTER   )
 	/* General */
 	#define NUM_SENSORS         ( 38   )


### PR DESCRIPTION
## Description
Changes `sensor_acc_conv` and `sensor_gyro_conv` to use an `int16_t` instead of a `uint16_t` with manual sign logic

Child - [driver](https://github.com/SunDevilRocketry/driver/pull/31)

### Testing
Tested this with a quick script and values are the same

### Other
why were we doing this

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code