### PR TITLE
feat: Add assert for debug builds that won't affect release stability

### DIFF
--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -143,6 +143,20 @@ typedef struct TEXT_MESSAGE
 #define assert_fail_fast( condition, error ) if ( !condition ) error_fail_fast( error )
 
 
+/*******************************************************************************
+*                                                                              *
+* MACRO:                                                                       * 
+*       debug_assert_fail_fast                                                 *
+*                                                                              *
+* DESCRIPTION:                                                                 *
+* 		Checks condition, if false calls error_fail_fast with error. Debug     *
+*       builds only -- release builds will do nothing.                         *
+*                                                                              *
+*******************************************************************************/
+#define debug_assert_fail_fast( condition, error ) \
+if ( !condition && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error )
+
+
 /*------------------------------------------------------------------------------
  Function Prototypes 
 ------------------------------------------------------------------------------*/

--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -140,7 +140,7 @@ typedef struct TEXT_MESSAGE
 * 		Checks condition, if false calls error_fail_fast with error            *
 *                                                                              *
 *******************************************************************************/
-#define assert_fail_fast( condition, error ) if ( !condition ) error_fail_fast( error )
+#define assert_fail_fast( condition, error ) if ( !(condition) ) error_fail_fast( error )
 
 
 /*******************************************************************************
@@ -154,7 +154,7 @@ typedef struct TEXT_MESSAGE
 *                                                                              *
 *******************************************************************************/
 #define debug_assert( condition, error ) \
-if ( !condition && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error )
+if ( !(condition) && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error )
 
 
 /*------------------------------------------------------------------------------

--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -146,14 +146,14 @@ typedef struct TEXT_MESSAGE
 /*******************************************************************************
 *                                                                              *
 * MACRO:                                                                       * 
-*       debug_assert_fail_fast                                                 *
+*       debug_assert                                                           *
 *                                                                              *
 * DESCRIPTION:                                                                 *
 * 		Checks condition, if false calls error_fail_fast with error. Debug     *
 *       builds only -- release builds will do nothing.                         *
 *                                                                              *
 *******************************************************************************/
-#define debug_assert_fail_fast( condition, error ) \
+#define debug_assert( condition, error ) \
 if ( !condition && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error )
 
 

--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -153,8 +153,13 @@ typedef struct TEXT_MESSAGE
 *       builds only -- release builds will do nothing.                         *
 *                                                                              *
 *******************************************************************************/
-#define debug_assert( condition, error ) \
-do { if ( !(condition) && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error ); } while(0)
+#if defined(DEBUG) || !defined(RELBLD)
+    #define debug_assert( condition, error ) \
+        do { if ( !(condition) ) error_fail_fast( error ); } while(0)
+#else
+    #define debug_assert( condition, error ) \
+        do { } while(0)
+#endif
 
 
 /*------------------------------------------------------------------------------

--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -140,7 +140,7 @@ typedef struct TEXT_MESSAGE
 * 		Checks condition, if false calls error_fail_fast with error            *
 *                                                                              *
 *******************************************************************************/
-#define assert_fail_fast( condition, error ) if ( !(condition) ) error_fail_fast( error )
+#define assert_fail_fast( condition, error ) do { if ( !(condition) ) error_fail_fast( error ); } while(0)
 
 
 /*******************************************************************************
@@ -154,7 +154,7 @@ typedef struct TEXT_MESSAGE
 *                                                                              *
 *******************************************************************************/
 #define debug_assert( condition, error ) \
-if ( !(condition) && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error )
+do { if ( !(condition) && ( defined(DEBUG) || !defined(RELBLD) ) ) error_fail_fast( error ); } while(0)
 
 
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Simple change to add a macro that asserts a condition on debug builds only to check assumptions. Does nothing on release builds to avoid halting execution in flight critical code. Enables better defensive programming practices.

Future idea (for rev 3) will be to send a message over the debug interface when this is hit and then continue execution.

### Issue Link
No issue -- just an idea I had while reading through https://github.com/SunDevilRocketry/driver/pull/28/.

### Testing
- [X] Passes existing unit tests
- [X] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

New tests in: https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/261

### Other
N/A

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code