### PR TITLE
Add error codes for I2C errors outside of init

### DIFF
--- a/error_sdr/error_sdr.h
+++ b/error_sdr/error_sdr.h
@@ -113,6 +113,8 @@ typedef enum _ERROR_CODE
     ERROR_LORA_SPI_INIT_ERROR          , /* Error with LoRa SPI init          */
     ERROR_LORA_INIT_ERROR              , /* Error with LoRa init              */
     ERROR_LORA_CMD_ERROR               , /* Error with LoRa command           */
+    ERROR_IMU_I2C_ERROR                , /* Error with IMU I2C handle         */
+    ERROR_BARO_I2C_ERROR               , /* Error with Baro I2C handle        */
     } ERROR_CODE;
 
 /* Error callback table entry */


### PR DESCRIPTION
## Description
Adds error codes to the error code enum for I2C errors.

@NArmistead: As a future improvement, I'd like us to consider changing the way we do the enum. Having to do a sub-pr in the submodule every time is a little inconvenient. We could instead define the error code enum in the project and have each submodule have an include file for their error codes. This would make mapping the decimal code to the text version a bit harder though, so I'm open to suggestions on other ways to accomplish this.

### Issue Link
Parent: https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/280

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code